### PR TITLE
Add out option completion

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,14 +7,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// sheetsCmd represents the sheets command
+// listSheetsCmd represents the list command.
 var listSheetsCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the sheets of the xlsx file",
 	Long:  `List the sheets of the xlsx file.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return fmt.Errorf("Please specify the xlsx file.")
+			return fmt.Errorf("please specify the xlsx file")
 		}
 		list, err := xlsxsql.XLSXSheet(args[0])
 		if err != nil {

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -87,7 +87,7 @@ func stdWriter(fileName string) (trdsql.Writer, error) {
 	return w, nil
 }
 
-// queryCmd represents the query command
+// queryCmd represents the query command.
 var queryCmd = &cobra.Command{
 	Use:   "query",
 	Short: "Executes the specified SQL query against the xlsx file",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	_ "github.com/noborus/xlsxsql"
 	"github.com/spf13/cobra"
 )
 
-// rootCmd represents the base command when called without any subcommands
+// rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "xlsxsql",
 	Short: "Execute SQL against xlsx file.",
@@ -28,7 +29,7 @@ Output to CSV and various formats.`,
 }
 
 var (
-	// Version represents the version
+	// Version represents the version.
 	Version string
 	// Revision set "git rev-parse --short HEAD"
 	Revision string
@@ -82,9 +83,14 @@ func init() {
 	// Input
 	rootCmd.PersistentFlags().IntVarP(&Skip, "skip", "s", 0, "Skip the number of lines")
 	rootCmd.PersistentFlags().BoolVarP(&Header, "header", "H", false, "Input header")
-
 	// Output
-	rootCmd.PersistentFlags().StringVarP(&OutFormat, "out", "o", "GUESS", "Output Format[CSV|AT|LTSV|JSON|JSONL|TBLN|RAW|MD|VF|YAML|XLSX]")
+	validOutFormats := []string{"CSV", "AT", "LTSV", "JSON", "JSONL", "TBLN", "RAW", "MD", "VF", "YAML", "XLSX"}
+	outputFormats := fmt.Sprintf("Output Format[%s]", strings.Join(validOutFormats, "|"))
+	rootCmd.PersistentFlags().StringVarP(&OutFormat, "out", "o", "GUESS", outputFormats)
+	// Register the completion function for the --out flag
+	_ = rootCmd.RegisterFlagCompletionFunc("out", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return validOutFormats, cobra.ShellCompDirectiveDefault
+	})
 	rootCmd.PersistentFlags().StringVarP(&OutFileName, "out-file", "O", "", "File name to output to file")
 	rootCmd.PersistentFlags().BoolVarP(&OutHeader, "out-header", "", false, "Output header")
 	rootCmd.PersistentFlags().StringVarP(&OutSheetName, "out-sheet", "", "", "Sheet name to output to xlsx file")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -84,9 +84,18 @@ func init() {
 	rootCmd.PersistentFlags().IntVarP(&Skip, "skip", "s", 0, "Skip the number of lines")
 	rootCmd.PersistentFlags().BoolVarP(&Header, "header", "H", false, "Input header")
 	// Output
-	validOutFormats := []string{"CSV", "AT", "LTSV", "JSON", "JSONL", "TBLN", "RAW", "MD", "VF", "YAML", "XLSX"}
+	validOutFormats := []string{"GUESS", "CSV", "AT", "LTSV", "JSON", "JSONL", "TBLN", "RAW", "MD", "VF", "YAML", "XLSX"}
 	outputFormats := fmt.Sprintf("Output Format[%s]", strings.Join(validOutFormats, "|"))
 	rootCmd.PersistentFlags().StringVarP(&OutFormat, "out", "o", "GUESS", outputFormats)
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		format := strings.ToUpper(OutFormat)
+		for _, valid := range validOutFormats {
+			if format == valid {
+				return nil
+			}
+		}
+		return fmt.Errorf("invalid output format: %s", OutFormat)
+	}
 	// Register the completion function for the --out flag
 	_ = rootCmd.RegisterFlagCompletionFunc("out", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return validOutFormats, cobra.ShellCompDirectiveDefault

--- a/cmd/table.go
+++ b/cmd/table.go
@@ -6,14 +6,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// tableCmd represents the table command
+// tableCmd represents the table command.
 var tableCmd = &cobra.Command{
 	Use:   "table",
 	Short: "SQL(SELECT * FROM table) for xlsx",
 	Long:  `Execute SELECT * FROM table, assuming the xlsx file as a table.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) != 1 {
-			return fmt.Errorf("Please specify the xlsx file.")
+			return fmt.Errorf("please specify the xlsx file")
 		}
 		query := "SELECT * FROM " + args[0]
 		return exec([]string{query})

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/xuri/efp v0.0.0-20241211021726-c4e992084aa6 // indirect
 	github.com/xuri/nfp v0.0.0-20240318013403-ab9948c2c4a7 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
-	golang.org/x/exp v0.0.0-20241210194714-1829a127f884 // indirect
+	golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 // indirect
 	golang.org/x/net v0.32.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	golang.org/x/term v0.27.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/xuri/nfp v0.0.0-20240318013403-ab9948c2c4a7/go.mod h1:WwHg+CVyzlv/TX9
 golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.31.0 h1:ihbySMvVjLAeSH1IbfcRTkD/iNscyz8rGzjF/E5hV6U=
 golang.org/x/crypto v0.31.0/go.mod h1:kDsLvtWBEx7MV9tJOj9bnXsPbxwJQ6csT/x4KIN4Ssk=
-golang.org/x/exp v0.0.0-20241210194714-1829a127f884 h1:Y/Mj/94zIQQGHVSv1tTtQBDaQaJe62U9bkDZKKyhPCU=
-golang.org/x/exp v0.0.0-20241210194714-1829a127f884/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67 h1:1UoZQm6f0P/ZO0w1Ri+f+ifG/gXhegadRdwBIXEFWDo=
+golang.org/x/exp v0.0.0-20241217172543-b2144cdd0a67/go.mod h1:qj5a5QZpwLU2NLQudwIN5koi3beDhSAlJwa67PuM98c=
 golang.org/x/image v0.18.0 h1:jGzIakQa/ZXI1I0Fxvaa9W7yP25TqT6cHIHn+6CqvSQ=
 golang.org/x/image v0.18.0/go.mod h1:4yyo5vMFQjVjUcVk4jEQcU9MGy/rulF5WvUILseCM2E=
 golang.org/x/mod v0.22.0 h1:D4nJWe9zXqHOmWqj4VMOJhvzj7bEZg4wEYa759z1pH4=


### PR DESCRIPTION
Add a completion to out format option.
Includes adding and fixing comments.
Update modules.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced command-line interface with dynamic output format descriptions and shell completion for the `--out` flag.
	- Default sheet name set to "Sheet1" when not specified for XLSX output.

- **Bug Fixes**
	- Improved error messages for argument specifications across commands for consistency.

- **Documentation**
	- Updated comments for clarity and consistency throughout the command files.

- **Chores**
	- Updated module version in the dependency management file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->